### PR TITLE
Action popup shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ config.*
 *~
 intltool-*.in
 INSTALL
+/aclocal.m4
+/compile
+/depcomp
+/install-sh
+/libtool
+/ltmain.sh
+/missing
+xfce4-clipman-plugin*.tar.bz2

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -116,6 +116,5 @@ echo
 echo "Build Configuration:"
 echo
 echo "    * Debug Support:    $enable_debug"
-echo "    * Unique:           $enable_unique"
 echo "    * QR Code:          $enable_qrencode"
 echo

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -70,16 +70,6 @@ XDT_CHECK_PACKAGE([XFCONF], [libxfconf-0], [4.10.0])
 XDT_CHECK_PACKAGE([LIBXPROTO], [xproto], [7.0.0])
 XDT_CHECK_PACKAGE([LIBXTST], [xtst], [1.0.0])
 
-dnl ***************************
-dnl *** Check for libunique ***
-dnl ***************************
-XDT_CHECK_OPTIONAL_PACKAGE([UNIQUE], [unique-3.0], [3.0.0], unique, [Unique support])
-if test x"$UNIQUE_FOUND" = x"yes"; then
-	enable_unique=yes
-else
-	enable_unique=no
-fi
-
 dnl *****************************
 dnl *** Check for libqrencode ***
 dnl *****************************

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -49,6 +49,7 @@ AM_PROG_CC_C_O()
 AC_PROG_LD()
 AC_PROG_INSTALL()
 AC_PROG_INTLTOOL()
+AC_PROG_LN_S()
 
 dnl **********************************
 dnl *** Check for standard headers ***

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -48,8 +48,8 @@ AC_PROG_CC()
 AM_PROG_CC_C_O()
 AC_PROG_LD()
 AC_PROG_INSTALL()
-AC_PROG_INTLTOOL()
 AC_PROG_LN_S()
+IT_PROG_INTLTOOL([0.35.0])
 
 dnl **********************************
 dnl *** Check for standard headers ***

--- a/data/appdata/.gitignore
+++ b/data/appdata/.gitignore
@@ -1,0 +1,1 @@
+xfce4-clipman.appdata.xml

--- a/panel-plugin/.gitignore
+++ b/panel-plugin/.gitignore
@@ -6,3 +6,4 @@ xfce4-clipman-plugin.desktop
 xfce4-clipman-settings
 xfce4-clipman.desktop
 xfce4-popup-clipman
+xfce4-popup-clipman-actions

--- a/panel-plugin/.gitignore
+++ b/panel-plugin/.gitignore
@@ -1,0 +1,8 @@
+settings-dialog_ui.h
+xfce4-clipman
+xfce4-clipman-actions.xml
+xfce4-clipman-plugin-autostart.desktop
+xfce4-clipman-plugin.desktop
+xfce4-clipman-settings
+xfce4-clipman.desktop
+xfce4-popup-clipman

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -49,7 +49,7 @@ xfce4_popup_clipman_LDADD =						\
 #
 
 xfce4_popup_clipman_actions_SOURCES =						\
-	xfce4-popup-clipman-actions.c						\
+	xfce4-popup-clipman.c						\
 	common.h							\
 	$(NULL)
 

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -10,7 +10,7 @@ INCLUDES =								\
 	-DPACKAGE_LOCALE_DIR=\"$(localedir)\"				\
 	$(NULL)
 
-bin_PROGRAMS = xfce4-clipman xfce4-popup-clipman xfce4-clipman-settings
+bin_PROGRAMS = xfce4-clipman xfce4-popup-clipman xfce4-clipman-settings xfce4-popup-clipman-actions
 
 #
 # Maintainer Mode
@@ -39,6 +39,28 @@ xfce4_popup_clipman_CFLAGS =                                            \
 	$(NULL)
 
 xfce4_popup_clipman_LDADD =						\
+	@LIBX11_LIBS@							\
+	@GDKX_LIBS@							\
+	@GTK_LIBS@							\
+	$(NULL)
+
+#
+# Action Popup Command
+#
+
+xfce4_popup_clipman_actions_SOURCES =						\
+	xfce4-popup-clipman-actions.c						\
+	common.h							\
+	$(NULL)
+
+xfce4_popup_clipman_actions_CFLAGS =                                            \
+	-DGSEAL_ENABLE							\
+	@LIBX11_CFLAGS@							\
+	@GDKX_CFLAGS@							\
+	@GTK_CFLAGS@							\
+	$(NULL)
+
+xfce4_popup_clipman_actions_LDADD =						\
 	@LIBX11_LIBS@							\
 	@GDKX_LIBS@							\
 	@GTK_LIBS@							\

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -62,7 +62,6 @@ xfce4_clipman_settings_CFLAGS =						\
 	@GTK_CFLAGS@							\
 	@LIBXFCE4UI_CFLAGS@						\
 	@XFCONF_CFLAGS@							\
-	@UNIQUE_CFLAGS@							\
 	$(NULL)
 
 xfce4_clipman_settings_LDADD =						\
@@ -71,7 +70,6 @@ xfce4_clipman_settings_LDADD =						\
 	@GTK_LIBS@							\
 	@LIBXFCE4UI_LIBS@						\
 	@XFCONF_LIBS@							\
-	@UNIQUE_LIBS@							\
 	$(NULL)
 
 #

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -10,7 +10,7 @@ INCLUDES =								\
 	-DPACKAGE_LOCALE_DIR=\"$(localedir)\"				\
 	$(NULL)
 
-bin_PROGRAMS = xfce4-clipman xfce4-popup-clipman xfce4-clipman-settings xfce4-popup-clipman-actions
+bin_PROGRAMS = xfce4-clipman xfce4-popup-clipman xfce4-clipman-settings 
 
 #
 # Maintainer Mode
@@ -39,28 +39,6 @@ xfce4_popup_clipman_CFLAGS =                                            \
 	$(NULL)
 
 xfce4_popup_clipman_LDADD =						\
-	@LIBX11_LIBS@							\
-	@GDKX_LIBS@							\
-	@GTK_LIBS@							\
-	$(NULL)
-
-#
-# Action Popup Command
-#
-
-xfce4_popup_clipman_actions_SOURCES =						\
-	xfce4-popup-clipman.c						\
-	common.h							\
-	$(NULL)
-
-xfce4_popup_clipman_actions_CFLAGS =                                            \
-	-DGSEAL_ENABLE							\
-	@LIBX11_CFLAGS@							\
-	@GDKX_CFLAGS@							\
-	@GTK_CFLAGS@							\
-	$(NULL)
-
-xfce4_popup_clipman_actions_LDADD =						\
 	@LIBX11_LIBS@							\
 	@GDKX_LIBS@							\
 	@GTK_LIBS@							\
@@ -239,3 +217,7 @@ CLEANFILES =								\
 DISTCLEANFILES =							\
 	$(BUILT_SOURCES)						\
 	$(NULL)
+
+install-exec-hook:
+	$(LN_S) -f $(exec_prefix)/bin/xfce4-popup-clipman $(exec_prefix)/bin/xfce4-popup-clipman-actions
+

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-INCLUDES =								\
+AM_CPPFLAGS =								\
 	-I${top_srcdir}							\
 	-DSYSCONFDIR=\"$(sysconfdir)\"					\
 	-DDATAROOTDIR=\"$(datarootdir)\"				\

--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -217,5 +217,5 @@ DISTCLEANFILES =							\
 	$(NULL)
 
 install-exec-hook:
-	$(LN_S) -f $(exec_prefix)/bin/xfce4-popup-clipman $(exec_prefix)/bin/xfce4-popup-clipman-actions
+	$(LN_S) -f $(exec_prefix)/bin/xfce4-popup-clipman $(DESTDIR)$(exec_prefix)/bin/xfce4-popup-clipman-actions
 

--- a/panel-plugin/actions.c
+++ b/panel-plugin/actions.c
@@ -432,6 +432,7 @@ static void
 __clipman_actions_entry_free (ClipmanActionsEntry *entry)
 {
   g_free (entry->action_name);
+  g_free (entry->pattern);
   g_regex_unref (entry->regex);
   g_hash_table_destroy (entry->commands);
   g_slice_free (ClipmanActionsEntry, entry);

--- a/panel-plugin/actions.c
+++ b/panel-plugin/actions.c
@@ -760,7 +760,7 @@ clipman_actions_match_with_menu (ClipmanActions *actions,
   gtk_container_add (GTK_CONTAINER (actions->priv->menu), mi);
 
   gtk_widget_show_all (actions->priv->menu);
-  while (usleep(100000) == -1);
+  usleep(100000);
   gtk_menu_popup (GTK_MENU (actions->priv->menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time ());
 
   g_slist_free (entries);

--- a/panel-plugin/actions.c
+++ b/panel-plugin/actions.c
@@ -689,8 +689,13 @@ clipman_actions_match_with_menu (ClipmanActions *actions,
   GSList *l, *entries;
   GdkModifierType state = 0;
   GdkDisplay* display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION (3, 20, 0)
+  GdkSeat *seat = gdk_display_get_default_seat (display);
+  GdkDevice *device = gdk_seat_get_pointer (seat);
+#else
   GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
-  GdkDevice* device = gdk_device_manager_get_client_pointer (device_manager);
+  GdkDevice *device = gdk_device_manager_get_client_pointer (device_manager);
+#endif
   GdkScreen* screen = gdk_screen_get_default ();
   GdkWindow * root_win = gdk_screen_get_root_window (screen);
 
@@ -760,7 +765,13 @@ clipman_actions_match_with_menu (ClipmanActions *actions,
   gtk_container_add (GTK_CONTAINER (actions->priv->menu), mi);
 
   gtk_widget_show_all (actions->priv->menu);
-  usleep(100000);
+
+  if(!gtk_widget_has_grab(actions->priv->menu))
+  {
+    gtk_grab_add(actions->priv->menu);
+  }
+
+
   gtk_menu_popup (GTK_MENU (actions->priv->menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time ());
 
   g_slist_free (entries);

--- a/panel-plugin/actions.c
+++ b/panel-plugin/actions.c
@@ -687,16 +687,18 @@ clipman_actions_match_with_menu (ClipmanActions *actions,
   ClipmanActionsEntry *entry;
   GtkWidget *mi;
   GSList *l, *entries;
-  GdkModifierType state;
+  GdkModifierType state = 0;
   GdkDisplay* display = gdk_display_get_default ();
   GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
   GdkDevice* device = gdk_device_manager_get_client_pointer (device_manager);
+  GdkScreen* screen = gdk_screen_get_default ();
+  GdkWindow * root_win = gdk_screen_get_root_window (screen);
 
   if (group == ACTION_GROUP_SELECTION)
     {
       gint ctrl_mask = 0;
 
-      gdk_window_get_device_position (NULL, device, NULL, NULL, &state);
+      gdk_window_get_device_position (root_win, device, NULL, NULL, &state);
       ctrl_mask = state & GDK_CONTROL_MASK;
       if (ctrl_mask && actions->priv->skip_action_on_key_down)
         {

--- a/panel-plugin/actions.c
+++ b/panel-plugin/actions.c
@@ -760,6 +760,7 @@ clipman_actions_match_with_menu (ClipmanActions *actions,
   gtk_container_add (GTK_CONTAINER (actions->priv->menu), mi);
 
   gtk_widget_show_all (actions->priv->menu);
+  while (usleep(100000) == -1);
   gtk_menu_popup (GTK_MENU (actions->priv->menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time ());
 
   g_slist_free (entries);

--- a/panel-plugin/collector.c
+++ b/panel-plugin/collector.c
@@ -244,6 +244,43 @@ clipman_collector_get (void)
   return singleton;
 }
 
+void
+clipman_collector_show_actions (void)
+{
+  ClipmanCollector   *collector;
+  const ClipmanHistoryItem *item;
+  ClipmanHistory     *history;
+  GSList *entries;
+  gint group;
+    
+  history = clipman_history_get();
+  collector = clipman_collector_get();
+
+  item = clipman_history_get_item_to_restore(history);
+
+  if (item == NULL)
+    return;
+
+  if (item->type == CLIPMAN_HISTORY_TYPE_TEXT)
+    {
+      entries = clipman_actions_match (collector->priv->actions, ACTION_GROUP_MANUAL, item->content.text);
+      if (entries == NULL)
+        {
+          group = ACTION_GROUP_SELECTION;
+        }
+      else
+        {
+          group = ACTION_GROUP_MANUAL;
+        }
+      g_slist_free (entries);
+      clipman_actions_match_with_menu (collector->priv->actions, group, item->content.text);
+    }
+  else
+    {
+      DBG("I can't show actions on item type %d", item->type);
+    }
+}
+
 /*
  * GObject
  */

--- a/panel-plugin/collector.c
+++ b/panel-plugin/collector.c
@@ -147,8 +147,13 @@ cb_check_primary_clipboard (ClipmanCollector *collector)
 {
   GdkModifierType state = 0;
   GdkDisplay* display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION (3, 20, 0)
+  GdkSeat *seat = gdk_display_get_default_seat (display);
+  GdkDevice *device = gdk_seat_get_pointer (seat);
+#else
   GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
-  GdkDevice* device = gdk_device_manager_get_client_pointer (device_manager);
+  GdkDevice *device = gdk_device_manager_get_client_pointer (device_manager);
+#endif
   GdkScreen* screen = gdk_screen_get_default ();
   GdkWindow * root_win = gdk_screen_get_root_window (screen);
 

--- a/panel-plugin/collector.c
+++ b/panel-plugin/collector.c
@@ -145,15 +145,17 @@ cb_clipboard_owner_change (ClipmanCollector *collector,
 static gboolean
 cb_check_primary_clipboard (ClipmanCollector *collector)
 {
-  GdkModifierType state;
+  GdkModifierType state = 0;
   GdkDisplay* display = gdk_display_get_default ();
   GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
   GdkDevice* device = gdk_device_manager_get_client_pointer (device_manager);
+  GdkScreen* screen = gdk_screen_get_default ();
+  GdkWindow * root_win = gdk_screen_get_root_window (screen);
 
   g_return_val_if_fail (GTK_IS_CLIPBOARD (collector->priv->default_clipboard) && GTK_IS_CLIPBOARD (collector->priv->primary_clipboard), FALSE);
 
   /* Postpone until the selection is done */
-  gdk_window_get_device_position (NULL, device, NULL, NULL, &state);
+  gdk_window_get_device_position (root_win, device, NULL, NULL, &state);
   if (state & (GDK_BUTTON1_MASK|GDK_SHIFT_MASK))
     return TRUE;
 

--- a/panel-plugin/collector.h
+++ b/panel-plugin/collector.h
@@ -52,6 +52,7 @@ GType                   clipman_collector_get_type              ();
 
 ClipmanCollector *      clipman_collector_get                   ();
 void                    clipman_collector_set_is_restoring      (ClipmanCollector *collector);
+void                    clipman_collector_show_actions          ();
 
 #endif /* !__CLIPMAN_COLLECTOR_H__ */
 

--- a/panel-plugin/common.h
+++ b/panel-plugin/common.h
@@ -45,8 +45,9 @@
  * Selection for the popup command
  */
 
-#define XFCE_CLIPMAN_SELECTION    "XFCE_CLIPMAN_SELECTION"
-#define XFCE_CLIPMAN_MESSAGE      "MENU"
+#define XFCE_CLIPMAN_SELECTION        "XFCE_CLIPMAN_SELECTION"
+#define XFCE_CLIPMAN_MESSAGE          "MENU"
+#define XFCE_CLIPMAN_ACTION_MESSAGE   "ACTIONS"
 
 /*
  * Action Groups

--- a/panel-plugin/main-status-icon.c
+++ b/panel-plugin/main-status-icon.c
@@ -150,6 +150,7 @@ cb_status_icon_popup_menu (MyPlugin *plugin, guint button, guint activate_time)
     }
 
   gtk_menu_set_screen (GTK_MENU (plugin->popup_menu), gtk_status_icon_get_screen (plugin->status_icon));
+  usleep(100000);
   gtk_menu_popup (GTK_MENU (plugin->popup_menu), NULL, NULL,
                   (GtkMenuPositionFunc)gtk_status_icon_position_menu, plugin->status_icon,
                   0, gtk_get_current_event_time ());

--- a/panel-plugin/main-status-icon.c
+++ b/panel-plugin/main-status-icon.c
@@ -150,7 +150,12 @@ cb_status_icon_popup_menu (MyPlugin *plugin, guint button, guint activate_time)
     }
 
   gtk_menu_set_screen (GTK_MENU (plugin->popup_menu), gtk_status_icon_get_screen (plugin->status_icon));
-  usleep(100000);
+
+  if(!gtk_widget_has_grab(plugin->popup_menu))
+  {
+    gtk_grab_add(plugin->popup_menu);
+  }
+
   gtk_menu_popup (GTK_MENU (plugin->popup_menu), NULL, NULL,
                   (GtkMenuPositionFunc)gtk_status_icon_position_menu, plugin->status_icon,
                   0, gtk_get_current_event_time ());

--- a/panel-plugin/menu.c
+++ b/panel-plugin/menu.c
@@ -161,7 +161,8 @@ cb_set_clipboard (GtkMenuItem *mi, const ClipmanHistoryItem *item)
       break;
 
     default:
-      g_assert_not_reached ();
+      DBG("Ignoring unknown history type %d", item->type);
+      return;
     }
 
   {
@@ -316,7 +317,8 @@ G_GNUC_END_IGNORE_DEPRECATIONS
           break;
 
         default:
-          g_assert_not_reached ();
+          DBG("Ignoring unknown history type %d", item->type);
+          continue;
         }
 
       g_signal_connect (mi, "activate", G_CALLBACK (cb_set_clipboard), item);

--- a/panel-plugin/plugin.c
+++ b/panel-plugin/plugin.c
@@ -353,6 +353,7 @@ plugin_popup_menu (MyPlugin *plugin)
 {
 #ifdef PANEL_PLUGIN
   gtk_menu_set_screen (GTK_MENU (plugin->menu), gtk_widget_get_screen (plugin->button));
+  usleep(100000);
   gtk_menu_popup (GTK_MENU (plugin->menu), NULL, NULL,
                   plugin->menu_position_func, plugin,
                   0, gtk_get_current_event_time ());
@@ -452,6 +453,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
           if (xfconf_channel_get_bool (plugin->channel, "/tweaks/popup-at-pointer", FALSE))
             {
+              usleep(100000);
               gtk_menu_popup (GTK_MENU (plugin->menu), NULL, NULL, NULL, NULL,
                               0, gtk_get_current_event_time ());
             }

--- a/panel-plugin/plugin.c
+++ b/panel-plugin/plugin.c
@@ -362,6 +362,7 @@ plugin_popup_menu (MyPlugin *plugin)
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   gtk_menu_set_screen (GTK_MENU (plugin->menu), gtk_status_icon_get_screen (plugin->status_icon));
 G_GNUC_END_IGNORE_DEPRECATIONS
+  usleep(100000);
   gtk_menu_popup (GTK_MENU (plugin->menu), NULL, NULL,
                   plugin->menu_position_func, plugin->status_icon,
                   0, gtk_get_current_event_time ());

--- a/panel-plugin/plugin.c
+++ b/panel-plugin/plugin.c
@@ -461,6 +461,9 @@ G_GNUC_END_IGNORE_DEPRECATIONS
             }
 
           return TRUE;
+        } else if (!g_ascii_strcasecmp (XFCE_CLIPMAN_ACTION_MESSAGE, evt->data.b))
+        {
+             clipman_collector_show_actions();
         }
     }
 

--- a/panel-plugin/plugin.c
+++ b/panel-plugin/plugin.c
@@ -501,9 +501,6 @@ xfce_popup_grab_available (GdkWindow *win, guint32 timestamp)
     GdkDisplay* display = gdk_window_get_display(win);
 #if GTK_CHECK_VERSION (3, 20, 0)
     GdkSeat *seat = gdk_display_get_default_seat (display);
-#else
-    GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
-    GdkDevice *device = gdk_device_manager_get_client_pointer (device_manager);
 #endif
     GdkGrabStatus g = GDK_GRAB_ALREADY_GRABBED;
     gboolean grab_failed = TRUE;
@@ -525,12 +522,14 @@ xfce_popup_grab_available (GdkWindow *win, guint32 timestamp)
           grab_failed = FALSE;
       }
 #else
-      g = gdk_device_grab(device, win, GDK_KEY_PRESS_MASK, TRUE, mask, NULL, timestamp);
+      G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+      g = gdk_keyboard_grab (win, TRUE, timestamp);
       if (g == GDK_GRAB_SUCCESS)
       {
-          gdk_device_ungrab(device, timestamp);
+          gdk_keyboard_ungrab(timestamp);
           grab_failed = FALSE;
       }
+      G_GNUC_END_IGNORE_DEPRECATIONS
 #endif
     }
 

--- a/panel-plugin/xfce4-popup-clipman.c
+++ b/panel-plugin/xfce4-popup-clipman.c
@@ -43,6 +43,7 @@ clipman_plugin_check_is_running (GtkWidget *widget,
   selection_name = g_strdup_printf (XFCE_CLIPMAN_SELECTION"%d",
                                     gdk_screen_get_number (gscreen));
   selection_atom = XInternAtom (display, selection_name, FALSE);
+  g_free(selection_name);
 
   if ((*xid = XGetSelectionOwner (display, selection_atom)))
     return TRUE;

--- a/panel-plugin/xfce4-popup-clipman.c
+++ b/panel-plugin/xfce4-popup-clipman.c
@@ -70,7 +70,14 @@ main (gint argc, gchar *argv[])
   event.xclient.type = ClientMessage;
   event.xclient.message_type = XInternAtom (display, "STRING", False);
   event.xclient.format = 8;
-  g_snprintf (event.xclient.data.b, sizeof (event.xclient.data.b), XFCE_CLIPMAN_MESSAGE);
+  if (!g_ascii_strcasecmp(argv[0], "xfce4-popup-clipman-actions"))
+    {
+      g_snprintf (event.xclient.data.b, sizeof (event.xclient.data.b), XFCE_CLIPMAN_ACTION_MESSAGE);
+    }
+  else
+    {
+      g_snprintf (event.xclient.data.b, sizeof (event.xclient.data.b), XFCE_CLIPMAN_MESSAGE);
+    }
 
   if (clipman_plugin_check_is_running (win, &id)) {
     event.xclient.window = id;

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,0 +1,3 @@
+.intltool-merge-cache
+POTFILES
+stamp-it

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 NULL =
 
-INCLUDES =								\
+AM_CPPFLAGS =								\
 	-I${top_srcdir}							\
 	-DSYSCONFDIR=\"$(sysconfdir)\"					\
 	-DDATADIR=\"$(datadir)\"					\

--- a/tests/test_targets.c
+++ b/tests/test_targets.c
@@ -31,7 +31,7 @@ cb (GtkClipboard *clipboard,
       selection_data = gtk_clipboard_wait_for_contents (clipboard, atoms[i]);
       if (selection_data != NULL)
         {
-          g_print ("%s (f:%d, l:%d)\n", atom_name, selection_data->format, selection_data->length);
+          g_print ("%s (f:%d, l:%d)\n", atom_name, gtk_selection_data_get_format (selection_data), gtk_selection_data_get_length(selection_data));
           gtk_selection_data_free (selection_data);
         }
       else

--- a/x11-clipboard-manager/Makefile.am
+++ b/x11-clipboard-manager/Makefile.am
@@ -1,6 +1,6 @@
 NULL = 
 
-INCLUDES =								\
+AM_CPPFLAGS =								\
 	-DGSEAL_ENABLE							\
 	-I${top_srcdir}							\
 	-DPACKAGE_LOCALE_DIR=\"$(localedir)\"				\

--- a/x11-clipboard-manager/gsd-clipboard-manager.c
+++ b/x11-clipboard-manager/gsd-clipboard-manager.c
@@ -215,8 +215,13 @@ primary_clipboard_store (GsdClipboardManager *manager)
         GdkModifierType state;
         gchar *text;
         GdkDisplay* display = gdk_display_get_default ();
+#if GTK_CHECK_VERSION (3, 20, 0)
+        GdkSeat *seat = gdk_display_get_default_seat (display);
+        GdkDevice *device = gdk_seat_get_pointer (seat);
+#else
         GdkDeviceManager *device_manager = gdk_display_get_device_manager (display);
-        GdkDevice* device = gdk_device_manager_get_client_pointer (device_manager);
+        GdkDevice *device = gdk_device_manager_get_client_pointer (device_manager);
+#endif
 
         gdk_window_get_device_position (NULL, device, NULL, NULL, &state);
         if (state & (GDK_BUTTON1_MASK|GDK_SHIFT_MASK)) {


### PR DESCRIPTION
I'm not sure if I can just add the "-f" to $(LN_S) in the panel-plugin/Makefile.am and not break other targets than bash/ubuntu :)

also I need to update documentation and other constraints as actions don't work "userfriendly" I think
and seem to be in conflict with the "Sync selections" option

The best way (for me) currently is to setup all actions then "disable" them (I'll rename this to "enable automatic actions" soon)
and then call xfce4-popup-clipman-actions to trigger the actions
